### PR TITLE
Transaction increase timeout fix error handling

### DIFF
--- a/android-stellar-sdk/src/main/java/org/stellar/sdk/Server.java
+++ b/android-stellar-sdk/src/main/java/org/stellar/sdk/Server.java
@@ -2,8 +2,6 @@ package org.stellar.sdk;
 
 import android.net.Uri;
 
-import com.google.gson.reflect.TypeToken;
-
 import org.stellar.sdk.requests.AccountsRequestBuilder;
 import org.stellar.sdk.requests.EffectsRequestBuilder;
 import org.stellar.sdk.requests.LedgersRequestBuilder;
@@ -12,9 +10,9 @@ import org.stellar.sdk.requests.OperationsRequestBuilder;
 import org.stellar.sdk.requests.OrderBookRequestBuilder;
 import org.stellar.sdk.requests.PathsRequestBuilder;
 import org.stellar.sdk.requests.PaymentsRequestBuilder;
-import org.stellar.sdk.requests.ResponseHandler;
 import org.stellar.sdk.requests.TradesRequestBuilder;
 import org.stellar.sdk.requests.TransactionsRequestBuilder;
+import org.stellar.sdk.responses.GsonSingleton;
 import org.stellar.sdk.responses.SubmitTransactionResponse;
 
 import java.io.IOException;
@@ -22,11 +20,11 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.concurrent.TimeUnit;
 
-import okhttp3.Call;
 import okhttp3.FormBody;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
+import okhttp3.ResponseBody;
 
 /**
  * Main class used to connect to Horizon server.
@@ -160,12 +158,15 @@ public class Server {
                 .url(transactionsUri.toString())
                 .post(formBody)
                 .build();
-        Call call = httpClient.newCall(request);
+        ResponseBody responseBody = httpClient.newCall(request)
+                .execute()
+                .body();
 
-        TypeToken type = new TypeToken<SubmitTransactionResponse>() {};
-        ResponseHandler<SubmitTransactionResponse> responseHandler =
-                new ResponseHandler<SubmitTransactionResponse>(httpClient, type);
-        return responseHandler.handleCall(call);
+        if (responseBody != null) {
+            String responseString = responseBody.string();
+            return GsonSingleton.getInstance().fromJson(responseString, SubmitTransactionResponse.class);
+        }
+        return null;
     }
 
     /**

--- a/android-stellar-sdk/src/main/java/org/stellar/sdk/Server.java
+++ b/android-stellar-sdk/src/main/java/org/stellar/sdk/Server.java
@@ -46,16 +46,18 @@ public class Server {
     }
 
     /**
-     * Creates server with input uri and read timeout for transactions, i.e. {@link Server#submitTransaction(Transaction)}
-     * <p>Read time out is the time waiting for server to respond, increase to support
-     * ledger close time above default of 10 sec</p>
+     * Creates server with input uri and timeout for transactions, i.e. {@link Server#submitTransaction(Transaction)}
+     * <p>Increase timeout to prevent timeout exception for transaction with ledger close
+     * time above default of 10 sec</p>
      * @param uri Horizon server uri
-     * @param transactionsTimeout transactions read timeout value
-     * @param timeUnit transactions read timeout unit
+     * @param transactionsTimeout transactions timeout value
+     * @param timeUnit transactions timeout unit
      */
     public Server(String uri, int transactionsTimeout, TimeUnit timeUnit) {
         createUri(uri);
         httpClient = new OkHttpClient.Builder()
+                .connectTimeout(transactionsTimeout, timeUnit)
+                .writeTimeout(transactionsTimeout, timeUnit)
                 .readTimeout(transactionsTimeout, timeUnit)
                 .build();
     }

--- a/android-stellar-sdk/src/main/java/org/stellar/sdk/requests/ResponseHandler.java
+++ b/android-stellar-sdk/src/main/java/org/stellar/sdk/requests/ResponseHandler.java
@@ -10,15 +10,14 @@ import org.stellar.sdk.responses.Response;
 import java.io.IOException;
 import java.net.URI;
 
-import okhttp3.Call;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.ResponseBody;
 
 public class ResponseHandler<T> {
 
-  private final TypeToken<T> type;
-  private final OkHttpClient client;
+  private TypeToken<T> type;
+  private OkHttpClient client = new OkHttpClient();
 
   /**
    * "Generics on a type are typically erased at runtime, except when the type is compiled with the
@@ -28,23 +27,9 @@ public class ResponseHandler<T> {
    *
    * @param type
    */
-  public ResponseHandler(OkHttpClient client, TypeToken<T> type) {
+  public ResponseHandler(TypeToken<T> type) {
     this.type = type;
-    this.client = client;
   }
-
-    /**
-     * "Generics on a type are typically erased at runtime, except when the type is compiled with the
-     * generic parameter bound. In that case, the compiler inserts the generic type information into
-     * the compiled class. In other cases, that is not possible."
-     * More info: http://stackoverflow.com/a/14506181
-     *
-     * @param type
-     */
-    public ResponseHandler(TypeToken<T> type) {
-        this.type = type;
-        this.client = new OkHttpClient();
-    }
 
   public T handleGetRequest(final URI uri) throws IOException {
     return handleResponse(client.newCall(
@@ -53,10 +38,6 @@ public class ResponseHandler<T> {
             .build()
     )
         .execute());
-  }
-
-  public T handleCall(final Call call) throws IOException {
-    return handleResponse(call.execute());
   }
 
   public T handleResponse(final okhttp3.Response response) throws IOException, TooManyRequestsException {

--- a/android-stellar-sdk/src/main/java/org/stellar/sdk/requests/ResponseHandler.java
+++ b/android-stellar-sdk/src/main/java/org/stellar/sdk/requests/ResponseHandler.java
@@ -10,14 +10,15 @@ import org.stellar.sdk.responses.Response;
 import java.io.IOException;
 import java.net.URI;
 
+import okhttp3.Call;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.ResponseBody;
 
 public class ResponseHandler<T> {
 
-  private TypeToken<T> type;
-  private OkHttpClient client = new OkHttpClient();
+  private final TypeToken<T> type;
+  private final OkHttpClient client;
 
   /**
    * "Generics on a type are typically erased at runtime, except when the type is compiled with the
@@ -27,9 +28,23 @@ public class ResponseHandler<T> {
    *
    * @param type
    */
-  public ResponseHandler(TypeToken<T> type) {
+  public ResponseHandler(OkHttpClient client, TypeToken<T> type) {
     this.type = type;
+    this.client = client;
   }
+
+    /**
+     * "Generics on a type are typically erased at runtime, except when the type is compiled with the
+     * generic parameter bound. In that case, the compiler inserts the generic type information into
+     * the compiled class. In other cases, that is not possible."
+     * More info: http://stackoverflow.com/a/14506181
+     *
+     * @param type
+     */
+    public ResponseHandler(TypeToken<T> type) {
+        this.type = type;
+        this.client = new OkHttpClient();
+    }
 
   public T handleGetRequest(final URI uri) throws IOException {
     return handleResponse(client.newCall(
@@ -38,6 +53,10 @@ public class ResponseHandler<T> {
             .build()
     )
         .execute());
+  }
+
+  public T handleCall(final Call call) throws IOException {
+    return handleResponse(call.execute());
   }
 
   public T handleResponse(final okhttp3.Response response) throws IOException, TooManyRequestsException {


### PR DESCRIPTION
expose option to increase timeout value for transaction operations.
transactions ledger close time in stellar has average of 5 sec but also variance, that means that sometimes transaction can take above 10 sec, which is our default (OkHttp) timeout for all queries, make this value changeable for transaction to minimize scenarios of timeout. 