### PR TITLE
Performance/Stability fixes

### DIFF
--- a/android-stellar-sdk/build.gradle
+++ b/android-stellar-sdk/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     implementation 'com.google.guava:guava:18.0'
     implementation 'com.google.code.gson:gson:2.8.2'
     implementation 'com.squareup.okhttp3:okhttp:3.9.1'
-    api 'com.github.kinecosystem:oksse:ba77baf1c8'
+    api 'com.github.kinecosystem:oksse:93f4ef7445f9c3db3c3bc2d1ccb2691fc7246810'
 
     testImplementation 'org.mockito:mockito-core:2.13.0'
     testImplementation "org.robolectric:robolectric:3.6.1"

--- a/android-stellar-sdk/build.gradle
+++ b/android-stellar-sdk/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     implementation 'com.google.guava:guava:18.0'
     implementation 'com.google.code.gson:gson:2.8.2'
     implementation 'com.squareup.okhttp3:okhttp:3.9.1'
-    api 'com.github.kinecosystem:oksse:06b006bfa9eb6a787e3677ce7ee492d7fa21f92c'
+    api 'com.github.kinecosystem:oksse:ba77baf1c8'
 
     testImplementation 'org.mockito:mockito-core:2.13.0'
     testImplementation "org.robolectric:robolectric:3.6.1"

--- a/android-stellar-sdk/src/main/java/org/stellar/sdk/federation/FederationServer.java
+++ b/android-stellar-sdk/src/main/java/org/stellar/sdk/federation/FederationServer.java
@@ -1,22 +1,18 @@
 package org.stellar.sdk.federation;
 
 import android.net.Uri;
-
 import com.google.common.net.InternetDomainName;
 import com.google.gson.reflect.TypeToken;
 import com.moandjiezana.toml.Toml;
-
-import org.stellar.sdk.requests.ResponseHandler;
-import org.stellar.sdk.responses.HttpResponseException;
-
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
+import org.stellar.sdk.requests.ResponseHandler;
+import org.stellar.sdk.responses.HttpResponseException;
 
 /**
  * FederationServer handles a network connection to a
@@ -138,7 +134,7 @@ public class FederationServer {
 
     TypeToken type = new TypeToken<FederationResponse>() {
     };
-    ResponseHandler<FederationResponse> responseHandler = new ResponseHandler<FederationResponse>(type);
+      ResponseHandler<FederationResponse> responseHandler = new ResponseHandler<FederationResponse>(httpClient, type);
 
     Request request = new Request.Builder()
         .url(uri.toString())

--- a/android-stellar-sdk/src/main/java/org/stellar/sdk/requests/AccountsRequestBuilder.java
+++ b/android-stellar-sdk/src/main/java/org/stellar/sdk/requests/AccountsRequestBuilder.java
@@ -2,20 +2,20 @@ package org.stellar.sdk.requests;
 
 import com.google.gson.reflect.TypeToken;
 import com.here.oksse.ServerSentEvent;
-
+import java.io.IOException;
+import java.net.URI;
+import okhttp3.OkHttpClient;
 import org.stellar.sdk.KeyPair;
 import org.stellar.sdk.responses.AccountResponse;
 import org.stellar.sdk.responses.Page;
-
-import java.io.IOException;
-import java.net.URI;
 
 /**
  * Builds requests connected to accounts.
  */
 public class AccountsRequestBuilder extends RequestBuilder {
-  public AccountsRequestBuilder(URI serverURI) {
-    super(serverURI, "accounts");
+
+  public AccountsRequestBuilder(OkHttpClient httpClient, URI serverURI) {
+    super(httpClient, serverURI, "accounts");
   }
 
   /**
@@ -25,7 +25,7 @@ public class AccountsRequestBuilder extends RequestBuilder {
    */
   public AccountResponse account(URI uri) throws IOException {
     TypeToken type = new TypeToken<AccountResponse>() {};
-    ResponseHandler<AccountResponse> responseHandler = new ResponseHandler<AccountResponse>(type);
+    ResponseHandler<AccountResponse> responseHandler = new ResponseHandler<AccountResponse>(httpClient, type);
     return responseHandler.handleGetRequest(uri);
   }
 
@@ -47,9 +47,11 @@ public class AccountsRequestBuilder extends RequestBuilder {
    * @throws TooManyRequestsException when too many requests were sent to the Horizon server.
    * @throws IOException
    */
-  public static Page<AccountResponse> execute(URI uri) throws IOException, TooManyRequestsException {
+  public static Page<AccountResponse> execute(OkHttpClient httpClient, URI uri)
+      throws IOException, TooManyRequestsException {
     TypeToken type = new TypeToken<Page<AccountResponse>>() {};
-    ResponseHandler<Page<AccountResponse>> responseHandler = new ResponseHandler<Page<AccountResponse>>(type);
+    ResponseHandler<Page<AccountResponse>> responseHandler = new ResponseHandler<Page<AccountResponse>>(httpClient,
+        type);
     return responseHandler.handleGetRequest(uri);
   }
 
@@ -75,7 +77,7 @@ public class AccountsRequestBuilder extends RequestBuilder {
    * @throws IOException
    */
   public Page<AccountResponse> execute() throws IOException, TooManyRequestsException {
-    return this.execute(this.buildUri());
+    return this.execute(httpClient, this.buildUri());
   }
 
   @Override

--- a/android-stellar-sdk/src/main/java/org/stellar/sdk/requests/EffectsRequestBuilder.java
+++ b/android-stellar-sdk/src/main/java/org/stellar/sdk/requests/EffectsRequestBuilder.java
@@ -1,23 +1,23 @@
 package org.stellar.sdk.requests;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.google.gson.reflect.TypeToken;
 import com.here.oksse.ServerSentEvent;
-
+import java.io.IOException;
+import java.net.URI;
+import okhttp3.OkHttpClient;
 import org.stellar.sdk.KeyPair;
 import org.stellar.sdk.responses.Page;
 import org.stellar.sdk.responses.effects.EffectResponse;
-
-import java.io.IOException;
-import java.net.URI;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Builds requests connected to effects.
  */
 public class EffectsRequestBuilder extends RequestBuilder {
-  public EffectsRequestBuilder(URI serverURI) {
-    super(serverURI, "effects");
+
+  public EffectsRequestBuilder(OkHttpClient httpClient, URI serverURI) {
+    super(httpClient, serverURI, "effects");
   }
 
   /**
@@ -69,9 +69,10 @@ public class EffectsRequestBuilder extends RequestBuilder {
    * @throws TooManyRequestsException when too many requests were sent to the Horizon server.
    * @throws IOException
    */
-  public static Page<EffectResponse> execute(URI uri) throws IOException, TooManyRequestsException {
+  public static Page<EffectResponse> execute(OkHttpClient httpClient, URI uri)
+      throws IOException, TooManyRequestsException {
     TypeToken type = new TypeToken<Page<EffectResponse>>() {};
-    ResponseHandler<Page<EffectResponse>> responseHandler = new ResponseHandler<Page<EffectResponse>>(type);
+    ResponseHandler<Page<EffectResponse>> responseHandler = new ResponseHandler<Page<EffectResponse>>(httpClient, type);
     return responseHandler.handleGetRequest(uri);
   }
 
@@ -97,7 +98,7 @@ public class EffectsRequestBuilder extends RequestBuilder {
    * @throws IOException
    */
   public Page<EffectResponse> execute() throws IOException, TooManyRequestsException {
-    return this.execute(this.buildUri());
+    return this.execute(httpClient, this.buildUri());
   }
 
   @Override

--- a/android-stellar-sdk/src/main/java/org/stellar/sdk/requests/LedgersRequestBuilder.java
+++ b/android-stellar-sdk/src/main/java/org/stellar/sdk/requests/LedgersRequestBuilder.java
@@ -2,19 +2,19 @@ package org.stellar.sdk.requests;
 
 import com.google.gson.reflect.TypeToken;
 import com.here.oksse.ServerSentEvent;
-
-import org.stellar.sdk.responses.LedgerResponse;
-import org.stellar.sdk.responses.Page;
-
 import java.io.IOException;
 import java.net.URI;
+import okhttp3.OkHttpClient;
+import org.stellar.sdk.responses.LedgerResponse;
+import org.stellar.sdk.responses.Page;
 
 /**
  * Builds requests connected to ledgers.
  */
 public class LedgersRequestBuilder extends RequestBuilder {
-  public LedgersRequestBuilder(URI serverURI) {
-    super(serverURI, "ledgers");
+
+  public LedgersRequestBuilder(OkHttpClient httpClient, URI serverURI) {
+    super(httpClient, serverURI, "ledgers");
   }
 
   /**
@@ -24,7 +24,7 @@ public class LedgersRequestBuilder extends RequestBuilder {
    */
   public LedgerResponse ledger(URI uri) throws IOException {
     TypeToken type = new TypeToken<LedgerResponse>() {};
-    ResponseHandler<LedgerResponse> responseHandler = new ResponseHandler<LedgerResponse>(type);
+    ResponseHandler<LedgerResponse> responseHandler = new ResponseHandler<LedgerResponse>(httpClient, type);
     return responseHandler.handleGetRequest(uri);
   }
 
@@ -46,9 +46,10 @@ public class LedgersRequestBuilder extends RequestBuilder {
    * @throws TooManyRequestsException when too many requests were sent to the Horizon server.
    * @throws IOException
    */
-  public static Page<LedgerResponse> execute(URI uri) throws IOException, TooManyRequestsException {
+  public static Page<LedgerResponse> execute(OkHttpClient httpClient, URI uri)
+      throws IOException, TooManyRequestsException {
     TypeToken type = new TypeToken<Page<LedgerResponse>>() {};
-    ResponseHandler<Page<LedgerResponse>> responseHandler = new ResponseHandler<Page<LedgerResponse>>(type);
+    ResponseHandler<Page<LedgerResponse>> responseHandler = new ResponseHandler<Page<LedgerResponse>>(httpClient, type);
     return responseHandler.handleGetRequest(uri);
   }
 
@@ -74,7 +75,7 @@ public class LedgersRequestBuilder extends RequestBuilder {
    * @throws IOException
    */
   public Page<LedgerResponse> execute() throws IOException, TooManyRequestsException {
-    return this.execute(this.buildUri());
+    return this.execute(httpClient, this.buildUri());
   }
 
   @Override

--- a/android-stellar-sdk/src/main/java/org/stellar/sdk/requests/OffersRequestBuilder.java
+++ b/android-stellar-sdk/src/main/java/org/stellar/sdk/requests/OffersRequestBuilder.java
@@ -1,22 +1,22 @@
 package org.stellar.sdk.requests;
 
-import com.google.gson.reflect.TypeToken;
+import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.gson.reflect.TypeToken;
+import java.io.IOException;
+import java.net.URI;
+import okhttp3.OkHttpClient;
 import org.stellar.sdk.KeyPair;
 import org.stellar.sdk.responses.OfferResponse;
 import org.stellar.sdk.responses.Page;
-
-import java.io.IOException;
-import java.net.URI;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Builds requests connected to offers.
  */
 public class OffersRequestBuilder extends RequestBuilder {
-  public OffersRequestBuilder(URI serverURI) {
-    super(serverURI, "offers");
+
+  public OffersRequestBuilder(OkHttpClient httpClient, URI serverURI) {
+    super(httpClient, serverURI, "offers");
   }
 
   /**
@@ -37,9 +37,10 @@ public class OffersRequestBuilder extends RequestBuilder {
    * @throws TooManyRequestsException when too many requests were sent to the Horizon server.
    * @throws IOException
    */
-  public static Page<OfferResponse> execute(URI uri) throws IOException, TooManyRequestsException {
+  public static Page<OfferResponse> execute(OkHttpClient httpClient, URI uri)
+      throws IOException, TooManyRequestsException {
     TypeToken type = new TypeToken<Page<OfferResponse>>() {};
-    ResponseHandler<Page<OfferResponse>> responseHandler = new ResponseHandler<Page<OfferResponse>>(type);
+    ResponseHandler<Page<OfferResponse>> responseHandler = new ResponseHandler<Page<OfferResponse>>(httpClient, type);
     return responseHandler.handleGetRequest(uri);
   }
 
@@ -50,7 +51,7 @@ public class OffersRequestBuilder extends RequestBuilder {
    * @throws IOException
    */
   public Page<OfferResponse> execute() throws IOException, TooManyRequestsException {
-    return this.execute(this.buildUri());
+    return this.execute(httpClient, this.buildUri());
   }
 
   @Override

--- a/android-stellar-sdk/src/main/java/org/stellar/sdk/requests/OperationsRequestBuilder.java
+++ b/android-stellar-sdk/src/main/java/org/stellar/sdk/requests/OperationsRequestBuilder.java
@@ -1,22 +1,22 @@
 package org.stellar.sdk.requests;
 
-import com.google.gson.reflect.TypeToken;
+import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.gson.reflect.TypeToken;
+import java.io.IOException;
+import java.net.URI;
+import okhttp3.OkHttpClient;
 import org.stellar.sdk.KeyPair;
 import org.stellar.sdk.responses.Page;
 import org.stellar.sdk.responses.operations.OperationResponse;
-
-import java.io.IOException;
-import java.net.URI;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Builds requests connected to operations.
  */
 public class OperationsRequestBuilder extends RequestBuilder {
-  public OperationsRequestBuilder(URI serverURI) {
-    super(serverURI, "operations");
+
+  public OperationsRequestBuilder(OkHttpClient httpClient, URI serverURI) {
+    super(httpClient, serverURI, "operations");
   }
 
   /**
@@ -26,7 +26,7 @@ public class OperationsRequestBuilder extends RequestBuilder {
    */
   public OperationResponse operation(URI uri) throws IOException {
     TypeToken type = new TypeToken<OperationResponse>() {};
-    ResponseHandler<OperationResponse> responseHandler = new ResponseHandler<OperationResponse>(type);
+    ResponseHandler<OperationResponse> responseHandler = new ResponseHandler<OperationResponse>(httpClient, type);
     return responseHandler.handleGetRequest(uri);
   }
 
@@ -80,9 +80,11 @@ public class OperationsRequestBuilder extends RequestBuilder {
    * @throws TooManyRequestsException when too many requests were sent to the Horizon server.
    * @throws IOException
    */
-  public static Page<OperationResponse> execute(URI uri) throws IOException, TooManyRequestsException {
+  public static Page<OperationResponse> execute(OkHttpClient httpClient, URI uri)
+      throws IOException, TooManyRequestsException {
     TypeToken type = new TypeToken<Page<OperationResponse>>() {};
-    ResponseHandler<Page<OperationResponse>> responseHandler = new ResponseHandler<Page<OperationResponse>>(type);
+    ResponseHandler<Page<OperationResponse>> responseHandler = new ResponseHandler<Page<OperationResponse>>(httpClient,
+        type);
     return responseHandler.handleGetRequest(uri);
   }
 
@@ -93,7 +95,7 @@ public class OperationsRequestBuilder extends RequestBuilder {
    * @throws IOException
    */
   public Page<OperationResponse> execute() throws IOException, TooManyRequestsException {
-    return this.execute(this.buildUri());
+    return this.execute(httpClient, this.buildUri());
   }
 
   @Override

--- a/android-stellar-sdk/src/main/java/org/stellar/sdk/requests/OrderBookRequestBuilder.java
+++ b/android-stellar-sdk/src/main/java/org/stellar/sdk/requests/OrderBookRequestBuilder.java
@@ -1,20 +1,20 @@
 package org.stellar.sdk.requests;
 
 import com.google.gson.reflect.TypeToken;
-
+import java.io.IOException;
+import java.net.URI;
+import okhttp3.OkHttpClient;
 import org.stellar.sdk.Asset;
 import org.stellar.sdk.AssetTypeCreditAlphaNum;
 import org.stellar.sdk.responses.OrderBookResponse;
-
-import java.io.IOException;
-import java.net.URI;
 
 /**
  * Builds requests connected to order book.
  */
 public class OrderBookRequestBuilder extends RequestBuilder {
-  public OrderBookRequestBuilder(URI serverURI) {
-    super(serverURI, "order_book");
+
+  public OrderBookRequestBuilder(OkHttpClient httpClient, URI serverURI) {
+    super(httpClient, serverURI, "order_book");
   }
 
   public OrderBookRequestBuilder buyingAsset(Asset asset) {
@@ -37,14 +37,15 @@ public class OrderBookRequestBuilder extends RequestBuilder {
     return this;
   }
 
-  public static OrderBookResponse execute(URI uri) throws IOException, TooManyRequestsException {
+  public static OrderBookResponse execute(OkHttpClient httpClient, URI uri)
+      throws IOException, TooManyRequestsException {
     TypeToken type = new TypeToken<OrderBookResponse>() {};
-    ResponseHandler<OrderBookResponse> responseHandler = new ResponseHandler<OrderBookResponse>(type);
+    ResponseHandler<OrderBookResponse> responseHandler = new ResponseHandler<OrderBookResponse>(httpClient, type);
     return responseHandler.handleGetRequest(uri);
   }
 
   public OrderBookResponse execute() throws IOException, TooManyRequestsException {
-    return this.execute(this.buildUri());
+    return this.execute(httpClient, this.buildUri());
   }
 
   @Override

--- a/android-stellar-sdk/src/main/java/org/stellar/sdk/requests/PathsRequestBuilder.java
+++ b/android-stellar-sdk/src/main/java/org/stellar/sdk/requests/PathsRequestBuilder.java
@@ -1,22 +1,22 @@
 package org.stellar.sdk.requests;
 
 import com.google.gson.reflect.TypeToken;
-
+import java.io.IOException;
+import java.net.URI;
+import okhttp3.OkHttpClient;
 import org.stellar.sdk.Asset;
 import org.stellar.sdk.AssetTypeCreditAlphaNum;
 import org.stellar.sdk.KeyPair;
 import org.stellar.sdk.responses.Page;
 import org.stellar.sdk.responses.PathResponse;
 
-import java.io.IOException;
-import java.net.URI;
-
 /**
  * Builds requests connected to paths.
  */
 public class PathsRequestBuilder extends RequestBuilder {
-  public PathsRequestBuilder(URI serverURI) {
-    super(serverURI, "paths");
+
+  public PathsRequestBuilder(OkHttpClient httpClient, URI serverURI) {
+    super(httpClient, serverURI, "paths");
   }
 
   public PathsRequestBuilder destinationAccount(KeyPair account) {
@@ -48,9 +48,10 @@ public class PathsRequestBuilder extends RequestBuilder {
    * @throws TooManyRequestsException when too many requests were sent to the Horizon server.
    * @throws IOException
    */
-  public static Page<PathResponse> execute(URI uri) throws IOException, TooManyRequestsException {
+  public static Page<PathResponse> execute(OkHttpClient httpClient, URI uri)
+      throws IOException, TooManyRequestsException {
     TypeToken type = new TypeToken<Page<PathResponse>>() {};
-    ResponseHandler<Page<PathResponse>> responseHandler = new ResponseHandler<Page<PathResponse>>(type);
+    ResponseHandler<Page<PathResponse>> responseHandler = new ResponseHandler<Page<PathResponse>>(httpClient, type);
     return responseHandler.handleGetRequest(uri);
   }
 
@@ -59,6 +60,6 @@ public class PathsRequestBuilder extends RequestBuilder {
    * @throws IOException
    */
   public Page<PathResponse> execute() throws IOException, TooManyRequestsException {
-    return this.execute(this.buildUri());
+    return this.execute(httpClient, this.buildUri());
   }
 }

--- a/android-stellar-sdk/src/main/java/org/stellar/sdk/requests/PaymentsRequestBuilder.java
+++ b/android-stellar-sdk/src/main/java/org/stellar/sdk/requests/PaymentsRequestBuilder.java
@@ -1,23 +1,23 @@
 package org.stellar.sdk.requests;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.google.gson.reflect.TypeToken;
 import com.here.oksse.ServerSentEvent;
-
+import java.io.IOException;
+import java.net.URI;
+import okhttp3.OkHttpClient;
 import org.stellar.sdk.KeyPair;
 import org.stellar.sdk.responses.Page;
 import org.stellar.sdk.responses.operations.OperationResponse;
-
-import java.io.IOException;
-import java.net.URI;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Builds requests connected to payments.
  */
 public class PaymentsRequestBuilder extends RequestBuilder {
-  public PaymentsRequestBuilder(URI serverURI) {
-    super(serverURI, "payments");
+
+  public PaymentsRequestBuilder(OkHttpClient httpClient, URI serverURI) {
+    super(httpClient, serverURI, "payments");
   }
 
   /**
@@ -59,9 +59,11 @@ public class PaymentsRequestBuilder extends RequestBuilder {
    * @throws TooManyRequestsException when too many requests were sent to the Horizon server.
    * @throws IOException
    */
-  public static Page<OperationResponse> execute(URI uri) throws IOException, TooManyRequestsException {
+  public static Page<OperationResponse> execute(OkHttpClient httpClient, URI uri)
+      throws IOException, TooManyRequestsException {
     TypeToken type = new TypeToken<Page<OperationResponse>>() {};
-    ResponseHandler<Page<OperationResponse>> responseHandler = new ResponseHandler<Page<OperationResponse>>(type);
+    ResponseHandler<Page<OperationResponse>> responseHandler = new ResponseHandler<Page<OperationResponse>>(httpClient,
+        type);
     return responseHandler.handleGetRequest(uri);
   }
 
@@ -87,7 +89,7 @@ public class PaymentsRequestBuilder extends RequestBuilder {
    * @throws IOException
    */
   public Page<OperationResponse> execute() throws IOException, TooManyRequestsException {
-    return this.execute(this.buildUri());
+    return this.execute(httpClient, this.buildUri());
   }
 
   @Override

--- a/android-stellar-sdk/src/main/java/org/stellar/sdk/requests/RequestBuilder.java
+++ b/android-stellar-sdk/src/main/java/org/stellar/sdk/requests/RequestBuilder.java
@@ -1,25 +1,28 @@
 package org.stellar.sdk.requests;
 
 import android.net.Uri;
-
 import java.net.URI;
 import java.util.ArrayList;
+import okhttp3.OkHttpClient;
 
 /**
  * Abstract class for request builders.
  */
 public abstract class RequestBuilder {
-  protected Uri.Builder uriBuilder;
-  private ArrayList<String> segments;
+
+  protected final Uri.Builder uriBuilder;
+  protected final OkHttpClient httpClient;
+  private final ArrayList<String> segments;
   private boolean segmentsAdded;
 
-  RequestBuilder(URI serverURI, String defaultSegment) {
+  RequestBuilder(OkHttpClient httpClient, URI serverURI, String defaultSegment) {
     uriBuilder = Uri.parse(serverURI.toString()).buildUpon();
     segments = new ArrayList<String>();
     if (defaultSegment != null) {
       this.setSegments(defaultSegment);
     }
     segmentsAdded = false; // Allow overwriting segments
+    this.httpClient = httpClient;
   }
 
   protected RequestBuilder setSegments(String... segments) {

--- a/android-stellar-sdk/src/main/java/org/stellar/sdk/requests/ResponseHandler.java
+++ b/android-stellar-sdk/src/main/java/org/stellar/sdk/requests/ResponseHandler.java
@@ -1,79 +1,82 @@
 package org.stellar.sdk.requests;
 
 import com.google.gson.reflect.TypeToken;
-
+import java.io.IOException;
+import java.net.URI;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.ResponseBody;
 import org.stellar.sdk.responses.ClientProtocolException;
 import org.stellar.sdk.responses.GsonSingleton;
 import org.stellar.sdk.responses.HttpResponseException;
 import org.stellar.sdk.responses.Response;
 
-import java.io.IOException;
-import java.net.URI;
-
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.ResponseBody;
-
 public class ResponseHandler<T> {
 
-  private TypeToken<T> type;
-  private OkHttpClient client = new OkHttpClient();
+    private TypeToken<T> type;
+    private OkHttpClient httpClient;
 
-  /**
-   * "Generics on a type are typically erased at runtime, except when the type is compiled with the
-   * generic parameter bound. In that case, the compiler inserts the generic type information into
-   * the compiled class. In other cases, that is not possible."
-   * More info: http://stackoverflow.com/a/14506181
-   *
-   * @param type
-   */
-  public ResponseHandler(TypeToken<T> type) {
-    this.type = type;
-  }
+    /**
+     * "Generics on a type are typically erased at runtime, except when the type is compiled with the
+     * generic parameter bound. In that case, the compiler inserts the generic type information into
+     * the compiled class. In other cases, that is not possible."
+     * More info: http://stackoverflow.com/a/14506181
+     */
+    public ResponseHandler(OkHttpClient httpClient, TypeToken<T> type) {
+        this.type = type;
+        this.httpClient = httpClient;
+    }
 
-  public T handleGetRequest(final URI uri) throws IOException {
-    return handleResponse(client.newCall(
-        new Request.Builder()
-            .url(uri.toString())
-            .build()
-    )
-        .execute());
-  }
+    public T handleGetRequest(final URI uri) throws IOException {
+        return handleResponse(httpClient.newCall(
+            new Request.Builder()
+                .url(uri.toString())
+                .build()
+        )
+            .execute());
+    }
 
-  public T handleResponse(final okhttp3.Response response) throws IOException, TooManyRequestsException {
-    // Too Many Requests
-    if (response.code() == 429) {
-      String retryAfterString = response.header("Retry-After");
-      if (retryAfterString != null) {
-        try {
-          int retryAfter = Integer.parseInt(retryAfterString);
-          throw new TooManyRequestsException(retryAfter);
-        } catch (Exception e) {
-          e.printStackTrace();
+    public T handleResponse(final okhttp3.Response response) throws IOException, TooManyRequestsException {
+        if (response == null) {
+            return null;
         }
-      }
-      throw new TooManyRequestsException(0);
-    }
+        try {
+            // Too Many Requests
+            if (response.code() == 429) {
+                String retryAfterString = response.header("Retry-After");
+                if (retryAfterString != null) {
+                    try {
+                        int retryAfter = Integer.parseInt(retryAfterString);
+                        throw new TooManyRequestsException(retryAfter);
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                }
+                throw new TooManyRequestsException(0);
+            }
 
-    // Other errors
-    if (response.code() >= 300) {
-      throw new HttpResponseException(response.code(), response.message());
-    }
-    // No content
-    ResponseBody responseBody = response.body();
-    if (responseBody == null) {
-      throw new ClientProtocolException("Response contains no content");
-    }
+            // Other errors
+            if (response.code() >= 300) {
+                throw new HttpResponseException(response.code(), response.message());
+            }
+            // No content
+            ResponseBody responseBody = response.body();
+            if (responseBody == null) {
+                throw new ClientProtocolException("Response contains no content");
+            }
 
-    T object = GsonSingleton.getInstance().fromJson(responseBody.string(), type.getType());
-    if (object instanceof Response) {
-      ((Response) object).setHeaders(
-          response.header("X-Ratelimit-Limit"),
-          response.header("X-Ratelimit-Remaining"),
-          response.header("X-Ratelimit-Reset")
-      );
+            T object = GsonSingleton.getInstance().fromJson(responseBody.string(), type.getType());
+            if (object instanceof Response) {
+                ((Response) object).setHeaders(
+                    response.header("X-Ratelimit-Limit"),
+                    response.header("X-Ratelimit-Remaining"),
+                    response.header("X-Ratelimit-Reset")
+                );
+            }
+            return object;
+        } finally {
+            response.close();
+        }
     }
-    return object;
-  }
 
 }

--- a/android-stellar-sdk/src/main/java/org/stellar/sdk/requests/TradesRequestBuilder.java
+++ b/android-stellar-sdk/src/main/java/org/stellar/sdk/requests/TradesRequestBuilder.java
@@ -1,20 +1,20 @@
 package org.stellar.sdk.requests;
 
 import com.google.gson.reflect.TypeToken;
-
+import java.io.IOException;
+import java.net.URI;
+import okhttp3.OkHttpClient;
 import org.stellar.sdk.Asset;
 import org.stellar.sdk.AssetTypeCreditAlphaNum;
 import org.stellar.sdk.responses.TradeResponse;
-
-import java.io.IOException;
-import java.net.URI;
 
 /**
  * Builds requests connected to trades.
  */
 public class TradesRequestBuilder extends RequestBuilder {
-    public TradesRequestBuilder(URI serverURI) {
-        super(serverURI, "order_book/trades");
+
+    public TradesRequestBuilder(OkHttpClient httpClient, URI serverURI) {
+        super(httpClient, serverURI, "order_book/trades");
     }
 
     public TradesRequestBuilder buyingAsset(Asset asset) {
@@ -37,13 +37,13 @@ public class TradesRequestBuilder extends RequestBuilder {
         return this;
     }
 
-    public static TradeResponse execute(URI uri) throws IOException, TooManyRequestsException {
+    public static TradeResponse execute(OkHttpClient httpClient, URI uri) throws IOException, TooManyRequestsException {
         TypeToken type = new TypeToken<TradeResponse>() {};
-        ResponseHandler<TradeResponse> responseHandler = new ResponseHandler<TradeResponse>(type);
+        ResponseHandler<TradeResponse> responseHandler = new ResponseHandler<TradeResponse>(httpClient, type);
         return responseHandler.handleGetRequest(uri);
     }
 
     public TradeResponse execute() throws IOException, TooManyRequestsException {
-        return this.execute(this.buildUri());
+        return this.execute(httpClient, this.buildUri());
     }
 }

--- a/android-stellar-sdk/src/main/java/org/stellar/sdk/requests/TransactionsRequestBuilder.java
+++ b/android-stellar-sdk/src/main/java/org/stellar/sdk/requests/TransactionsRequestBuilder.java
@@ -1,23 +1,26 @@
 package org.stellar.sdk.requests;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.google.gson.reflect.TypeToken;
 import com.here.oksse.ServerSentEvent;
-
+import java.io.IOException;
+import java.net.URI;
+import okhttp3.OkHttpClient;
 import org.stellar.sdk.KeyPair;
 import org.stellar.sdk.responses.Page;
 import org.stellar.sdk.responses.TransactionResponse;
-
-import java.io.IOException;
-import java.net.URI;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Builds requests connected to transactions.
  */
 public class TransactionsRequestBuilder extends RequestBuilder {
-  public TransactionsRequestBuilder(URI serverURI) {
-    super(serverURI, "transactions");
+
+  private final OkHttpClient httpClient;
+
+  public TransactionsRequestBuilder(OkHttpClient httpClient, URI serverURI) {
+    super(httpClient, serverURI, "transactions");
+    this.httpClient = httpClient;
   }
 
   /**
@@ -27,7 +30,7 @@ public class TransactionsRequestBuilder extends RequestBuilder {
    */
   public TransactionResponse transaction(URI uri) throws IOException {
     TypeToken type = new TypeToken<TransactionResponse>() {};
-    ResponseHandler<TransactionResponse> responseHandler = new ResponseHandler<TransactionResponse>(type);
+    ResponseHandler<TransactionResponse> responseHandler = new ResponseHandler<TransactionResponse>(httpClient, type);
     return responseHandler.handleGetRequest(uri);
   }
 
@@ -70,9 +73,11 @@ public class TransactionsRequestBuilder extends RequestBuilder {
    * @throws TooManyRequestsException when too many requests were sent to the Horizon server.
    * @throws IOException
    */
-  public static Page<TransactionResponse> execute(URI uri) throws IOException, TooManyRequestsException {
+  public static Page<TransactionResponse> execute(OkHttpClient httpClient, URI uri)
+      throws IOException, TooManyRequestsException {
     TypeToken type = new TypeToken<Page<TransactionResponse>>() {};
-    ResponseHandler<Page<TransactionResponse>> responseHandler = new ResponseHandler<Page<TransactionResponse>>(type);
+    ResponseHandler<Page<TransactionResponse>> responseHandler = new ResponseHandler<Page<TransactionResponse>>(
+        httpClient, type);
     return responseHandler.handleGetRequest(uri);
   }
 
@@ -98,7 +103,7 @@ public class TransactionsRequestBuilder extends RequestBuilder {
    * @throws IOException
    */
   public Page<TransactionResponse> execute() throws IOException, TooManyRequestsException {
-    return this.execute(this.buildUri());
+    return this.execute(httpClient, this.buildUri());
   }
 
   @Override

--- a/android-stellar-sdk/src/main/java/org/stellar/sdk/responses/Page.java
+++ b/android-stellar-sdk/src/main/java/org/stellar/sdk/responses/Page.java
@@ -2,13 +2,12 @@ package org.stellar.sdk.responses;
 
 import com.google.gson.annotations.SerializedName;
 import com.google.gson.reflect.TypeToken;
-
-import org.stellar.sdk.requests.ResponseHandler;
-
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import okhttp3.OkHttpClient;
+import org.stellar.sdk.requests.ResponseHandler;
 
 /**
  * Represents page of objects.
@@ -34,13 +33,14 @@ public class Page<T> extends Response {
    * @return The next page of results or null when there is no more results
    * @throws URISyntaxException
    * @throws IOException
+   * @param httpClient
    */
-  public Page<T> getNextPage() throws URISyntaxException, IOException {
+  public Page<T> getNextPage(OkHttpClient httpClient) throws URISyntaxException, IOException {
     if (this.getLinks().getNext() == null) {
       return null;
     }
     TypeToken type = new TypeToken<Page<T>>() {};
-    ResponseHandler<Page<T>> responseHandler = new ResponseHandler<Page<T>>(type);
+    ResponseHandler<Page<T>> responseHandler = new ResponseHandler<Page<T>>(httpClient, type);
     URI uri = new URI(this.getLinks().getNext().getHref());
     return responseHandler.handleGetRequest(uri);
   }

--- a/android-stellar-sdk/src/main/java/org/stellar/sdk/responses/Response.java
+++ b/android-stellar-sdk/src/main/java/org/stellar/sdk/responses/Response.java
@@ -7,9 +7,9 @@ public abstract class Response {
 
   public void setHeaders(String limit, String remaining, String reset) {
     try {
-      this.rateLimitLimit = safeParse(limit);
-      this.rateLimitRemaining = safeParse(remaining);
-      this.rateLimitReset = safeParse(reset);
+        this.rateLimitLimit = Integer.parseInt(limit);
+        this.rateLimitRemaining = Integer.parseInt(remaining);
+        this.rateLimitReset = Integer.parseInt(reset);
     } catch (Exception e) {
       e.printStackTrace();
     }

--- a/android-stellar-sdk/src/main/java/org/stellar/sdk/responses/Response.java
+++ b/android-stellar-sdk/src/main/java/org/stellar/sdk/responses/Response.java
@@ -7,12 +7,16 @@ public abstract class Response {
 
   public void setHeaders(String limit, String remaining, String reset) {
     try {
-      this.rateLimitLimit = Integer.parseInt(limit);
-      this.rateLimitRemaining = Integer.parseInt(remaining);
-      this.rateLimitReset = Integer.parseInt(reset);
+      this.rateLimitLimit = safeParse(limit);
+      this.rateLimitRemaining = safeParse(remaining);
+      this.rateLimitReset = safeParse(reset);
     } catch (Exception e) {
       e.printStackTrace();
     }
+  }
+
+  private int safeParse(String number) {
+    return number == null || number.isEmpty() ? 0 : Integer.parseInt(number);
   }
 
   /**

--- a/android-stellar-sdk/src/test/java/org/stellar/sdk/responses/PathsPageDeserializerTest.java
+++ b/android-stellar-sdk/src/test/java/org/stellar/sdk/responses/PathsPageDeserializerTest.java
@@ -1,17 +1,16 @@
 package org.stellar.sdk.responses;
 
-import com.google.gson.reflect.TypeToken;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
+import com.google.gson.reflect.TypeToken;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import okhttp3.OkHttpClient;
 import org.junit.Assert;
 import org.junit.Test;
 import org.stellar.sdk.Asset;
 import org.stellar.sdk.KeyPair;
-
-import java.io.IOException;
-import java.net.URISyntaxException;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 public class PathsPageDeserializerTest {
 
@@ -19,7 +18,7 @@ public class PathsPageDeserializerTest {
   public void testDeserialize() throws IOException, URISyntaxException {
     Page<PathResponse> pathsPage = GsonSingleton.getInstance().fromJson(json, new TypeToken<Page<PathResponse>>() {}.getType());
 
-    assertNull(pathsPage.getNextPage());
+    assertNull(pathsPage.getNextPage(new OkHttpClient()));
 
     assertEquals(pathsPage.getRecords().get(0).getDestinationAmount(), "20.0000000");
     Assert.assertEquals(pathsPage.getRecords().get(0).getDestinationAsset(), Asset.createNonNativeAsset("EUR", KeyPair.fromAccountId("GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN")));


### PR DESCRIPTION
* always close OkHttp responses (+ updating OkSse version to close response in SSE requests, see https://github.com/kinecosystem/oksse/pull/2)
* reuse OkHttpClient instances (as it's creation is costly and this the best practice suggested by OkHttp)
* avoid parsing errors in tests by avoiding parsing empty strings/null
