### PR TITLE
add x509 to proguard ignore rules

### DIFF
--- a/android-stellar-sdk/proguard-rules.pro
+++ b/android-stellar-sdk/proguard-rules.pro
@@ -17,3 +17,6 @@
 -keep class * implements com.google.gson.TypeAdapterFactory
 -keep class * implements com.google.gson.JsonSerializer
 -keep class * implements com.google.gson.JsonDeserializer
+
+# Ignore usages of x509 in eddsa library as it's not in use in our case
+-dontwarn sun.security.x509.**


### PR DESCRIPTION
we're not using x509 in eddsa library so it's safe to ignore (use of x509
is new to the latest version of eddsa lib) sun.security packages are internal
to the jvm and are discourge from using, that's why proguard is not recognize.